### PR TITLE
Fetch missions

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,7 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { getMissions } from '../redux/Missions/missionSlice';
 
-const Missions = () => (
-  <div>Missions</div>
-);
+const Missions = () => {
+  const dispatch = useDispatch();
+  const missions = useSelector((state) => state.missions.missionData);
+
+  useEffect(() => {
+    if (missions.length === 0) {
+      dispatch(getMissions());
+    }
+  }, [dispatch, missions.length]);
+
+  return (
+    <div>
+      {missions.map((m) => (
+        <div key={m.mission_id}>
+          <div>{m.mission_id}</div>
+          <div>{m.mission_name}</div>
+          <div>{m.description}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
 
 export default Missions;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
 import './index.css';
 import App from './App';
+import store from './redux/configureStore';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
 );

--- a/src/redux/Missions/fetchMissionAPI.js
+++ b/src/redux/Missions/fetchMissionAPI.js
@@ -1,0 +1,7 @@
+const fetchMissions = async () => {
+  const response = await fetch('https://api.spacexdata.com/v3/missions');
+  const responseJSON = await response.json();
+  return responseJSON;
+};
+
+export default fetchMissions;

--- a/src/redux/Missions/missionSlice.js
+++ b/src/redux/Missions/missionSlice.js
@@ -1,0 +1,38 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import fetchMissions from './fetchMissionAPI';
+
+const initialState = { loading: false, missionData: [], error: '' };
+
+export const getMissions = createAsyncThunk('missions/fetchMissions', async () => {
+  const missionData = await fetchMissions().then((data) => data);
+  const mission = [];
+  missionData.forEach((element) => {
+    mission.push({
+      mission_id: element.mission_id,
+      mission_name: element.mission_name,
+      description: element.description,
+    });
+  });
+  return mission;
+});
+
+const missionSlice = createSlice({
+  name: 'missions',
+  initialState,
+  extraReducers: (builder) => {
+    builder.addCase(getMissions.pending, (state) => {
+      const newState = { ...state, loading: true };
+      return newState;
+    });
+    builder.addCase(getMissions.fulfilled, (state, action) => {
+      const newState = { ...state, missionData: action.payload, loading: false };
+      return newState;
+    });
+    builder.addCase(getMissions.rejected, (state, action) => {
+      const newState = { ...state, missionData: [], error: action.error.message };
+      return newState;
+    });
+  },
+});
+
+export default missionSlice.reducer;

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import missionReducer from './Missions/missionSlice';
+
+const store = configureStore({
+  reducer: {
+    missions: missionReducer,
+  },
+});
+
+export default store;


### PR DESCRIPTION
In this PR, I have:

- Fetched data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
- Once the data are fetched, dispatched an action to store the selected data (mission_id, mission_name, and description)  in Redux store.
- Only dispatched the action once and did not add data to store on every re-render (i.e. when changing views / using navigation)